### PR TITLE
Add Carl chatbot

### DIFF
--- a/carl_bot/README.md
+++ b/carl_bot/README.md
@@ -1,0 +1,30 @@
+# Carl Chatbot
+
+This is a simple AI chatbot named **Carl**. It uses the
+[Hugging Face Transformers](https://huggingface.co/transformers/) library to
+generate responses using a text-generation model such as `gpt2`.
+
+## Requirements
+
+- Python 3.8+
+- `transformers` library
+- `torch` (required by transformers)
+
+Install dependencies with:
+
+```bash
+pip install transformers torch
+```
+
+Optionally set the `CARL_MODEL` environment variable to choose a different model.
+
+## Usage
+
+Run the chatbot from the command line:
+
+```bash
+python carl_chatbot.py
+```
+
+Type your messages after the `You:` prompt. Type `exit`, `quit`, or `bye` to
+leave the chat.

--- a/carl_bot/carl_chatbot.py
+++ b/carl_bot/carl_chatbot.py
@@ -1,0 +1,34 @@
+import os
+from transformers import pipeline
+
+
+def load_model():
+    model_name = os.environ.get("CARL_MODEL", "gpt2")
+    generator = pipeline("text-generation", model=model_name)
+    return generator
+
+def generate_reply(generator, prompt, max_length=50):
+    response = generator(prompt, max_length=max_length, num_return_sequences=1)
+    text = response[0]['generated_text']
+    # Remove the prompt from the generated text if repeated
+    if text.startswith(prompt):
+        text = text[len(prompt):].strip()
+    return text.strip()
+
+def chat():
+    print("Carl: Hello! I'm Carl, your friendly AI chatbot. Ask me anything!")
+    generator = load_model()
+    while True:
+        try:
+            user_input = input("You: ")
+        except EOFError:
+            break
+        if user_input.lower() in {"exit", "quit", "bye"}:
+            print("Carl: Goodbye!")
+            break
+        prompt = f"User: {user_input}\nCarl:" 
+        reply = generate_reply(generator, prompt)
+        print(f"Carl: {reply}")
+
+if __name__ == "__main__":
+    chat()


### PR DESCRIPTION
## Summary
- add a simple Carl chatbot using Hugging Face transformers
- document how to run the bot

## Testing
- `python -m py_compile carl_bot/carl_chatbot.py`
- *(failed to fully install and run due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684838207a10832f915dc39049175e18